### PR TITLE
change from onPreResponse to onPostAuth

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const authorization = require(path.join(__dirname, 'lib', 'authorization.js'))
 function plugin (server, opts, next) {
   debug('opts:')
   debug(opts)
-  server.ext('onPreResponse', function (req, reply) {
+  server.ext('onPostAuth', function (req, reply) {
     debug('request for %s caught', req.path)
     if (opts.exempt && opts.exempt.includes(req.path)) {
       debug('%s is exempt', req.path)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.3.0",
     "pre-commit": "^1.2.2",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "standard": "^10.0.3"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
Seems weird to let them go through the handler, just to forbid the response.